### PR TITLE
Add support for custom `http.Client` and improve documentation


### DIFF
--- a/api/accountdetails.go
+++ b/api/accountdetails.go
@@ -1,5 +1,7 @@
 package api
 
+// Account is used to construct and return Account Details
+// For more information on the provided data, see https://uptimerobot.com/api/#getAccountDetailsWrap
 type Account struct {
 	Email           string `xml:"email,string,attr"`
 	MonitorLimit    int    `xml:"monitor_limit,int,attr"`
@@ -19,6 +21,7 @@ func (c *Client) AccountDetails() *AccountDetails {
 	return &AccountDetails{c}
 }
 
+// Returns Account Details for the current client
 func (ad *AccountDetails) Get() (*Account, error) {
 	r := ad.c.newRequest("POST", "/getAccountDetails")
 	_, resp, err := requireOK(ad.c.doRequest(r))

--- a/api/api.go
+++ b/api/api.go
@@ -79,6 +79,8 @@ func (r *request) toHTTP() (*http.Request, error) {
 	return req, nil
 }
 
+// newRequest returns a request containing all the required data
+// to construct an HTTP request.
 func (c *Client) newRequest(method, path string) *request {
 	addressSplit := strings.Split(c.config.Address, "/")
 	host := addressSplit[0]

--- a/api/api.go
+++ b/api/api.go
@@ -18,8 +18,7 @@ type Config struct {
 	// Address is the address of the UptimeRobot service
 	Address string
 
-	// HttpClient is the client to use. Default will be
-	// used if not provided.
+	// HttpClient is the client to use. This will be an http.defaultClient if nothing is provided.
 	HttpClient *http.Client
 
 	// WaitTime limits how long a Watch will block. If not provided,
@@ -44,11 +43,16 @@ type request struct {
 	obj    interface{}
 }
 
-// NewClient returns a new client
-func NewClient(apikey string) (*Client, error) {
+// NewClient returns a new client, wrapping the httpClient provided
+// This allows users to specify things like http.Client.Timeout,
+// or use the same default client previously provided.
+func NewClient(apikey string, httpClient *http.Client) (*Client, error) {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
 	config := &Config{
 		Address:    endpoint,
-		HttpClient: http.DefaultClient,
+		HttpClient: httpClient,
 		APIKey:     apikey,
 	}
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,13 +1,14 @@
 package api
 
 import (
+	"net/http"
 	"os"
 	"testing"
 )
 
 func makeClient(t *testing.T) *Client {
 	// Create client
-	client, err := NewClient(os.Getenv("UPTIMEROBOT_KEY"))
+	client, err := NewClient(os.Getenv("UPTIMEROBOT_KEY"), http.DefaultClient)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/api/monitors.go
+++ b/api/monitors.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 )
 
+// Allows mapping human readable words to the integers uptimerobot expects for monitoring types
+// i.e. http, keyword, ping, port
 type MonitorType int
 
 const (
@@ -14,34 +16,47 @@ const (
 	Port
 )
 
+// NewMonitorRequest provides the data to create a new Monitor
 type NewMonitorRequest struct {
+	// Friendly name for the monitor
 	FriendlyName string
-	Url          string
-	MonitorType  MonitorType
+	// Url to monitor
+	Url string
+	// Type of monitoring to use
+	MonitorType MonitorType
 }
 
+// EditMonitorRequest provides the data to edit a specified Monitor
 type EditMonitorRequest struct {
-	Id           int
+	// Id of the monitor to edit
+	Id int
+	// New friendly name
 	FriendlyName string
-	Url          string
+	// New url
+	Url string
 }
 
+// DeleteMonitorRequest provides the data to delete a specified Monitor
 type DeleteMonitorRequest struct {
 	Id int
 }
 
+// MonitorResponse contains an ID for a monitor
 type MonitorResponse struct {
 	ID int `xml:"id,int,attr"`
 }
 
+// GetMonitorsRequest provides the data to request Monitor information
 type GetMonitorsRequest struct {
 	MonitorId int
 }
 
+// XMLMonitors contains a slice of XMLMonitor structs
 type XMLMonitors struct {
 	Monitors []XMLMonitor `xml:"monitor"`
 }
 
+// XML Monitor is used to construct and return details for one monitor
 type XMLMonitor struct {
 	ID               int                 `xml:"id,int,attr"`
 	FriendlyName     string              `xml:"friendly_name,string,attr"`
@@ -49,10 +64,12 @@ type XMLMonitor struct {
 	ResponseTimeList XMLResponseTimeList `xml:"response_times"`
 }
 
+// XMLResponseTimeList contains a slice of ResponseTime structs
 type XMLResponseTimeList struct {
 	ResponseTimes []ResponseTime `xml:"response_time"`
 }
 
+// ResponseTime is used to parse the response time data for a monitor
 type ResponseTime struct {
 	Date  int `xml:"datetime,int,attr"`
 	Value int `xml:"value,int,attr"`
@@ -68,6 +85,8 @@ func (c *Client) Monitors() *Monitors {
 	return &Monitors{c}
 }
 
+// Returns a MonitorResponse, containing an ID for the monitor edited,
+// or an error.
 func (ad *Monitors) New(req NewMonitorRequest) (*MonitorResponse, error) {
 	r := ad.c.newRequest("POST", "/newMonitor")
 	err := r.setNewMonitorRequest(req)
@@ -88,6 +107,8 @@ func (ad *Monitors) New(req NewMonitorRequest) (*MonitorResponse, error) {
 	return out, nil
 }
 
+// Helper func for New to construct http request body
+// using the provided NewMonitorRequest struct
 func (r *request) setNewMonitorRequest(req NewMonitorRequest) error {
 	if req.FriendlyName == "" {
 		return errors.New("FriendlyName: required value")
@@ -101,6 +122,8 @@ func (r *request) setNewMonitorRequest(req NewMonitorRequest) error {
 	return nil
 }
 
+// Returns a MonitorResponse, containing an ID for the monitor edited,
+// or an error.
 // Per https://uptimerobot.com/api/#editMonitorWrap, monitor type cannot be edited.
 // To change type, monitors should be deleted and recreated.
 func (ad *Monitors) Edit(req EditMonitorRequest) (*MonitorResponse, error) {
@@ -123,6 +146,8 @@ func (ad *Monitors) Edit(req EditMonitorRequest) (*MonitorResponse, error) {
 	return out, nil
 }
 
+// Helper func for Edit to construct http request body
+// using the provided EditMonitorRequest struct
 func (r *request) setEditMonitorRequest(req EditMonitorRequest) error {
 	if req.Id == 0 {
 		return errors.New("Id: required value")
@@ -137,6 +162,8 @@ func (r *request) setEditMonitorRequest(req EditMonitorRequest) error {
 	return nil
 }
 
+// Returns a MonitorResponse, containing an ID for the monitor deleted,
+// or an error
 func (ad *Monitors) Delete(req DeleteMonitorRequest) (*MonitorResponse, error) {
 	r := ad.c.newRequest("POST", "/deleteMonitor")
 	err := r.setDeleteMonitorRequest(req)
@@ -157,6 +184,8 @@ func (ad *Monitors) Delete(req DeleteMonitorRequest) (*MonitorResponse, error) {
 	return out, nil
 }
 
+// Helper func for Delete to construct http request body
+// using the provided DeleteMonitorRequest struct
 func (r *request) setDeleteMonitorRequest(req DeleteMonitorRequest) error {
 	if req.Id == 0 {
 		return errors.New("Id: required value")
@@ -165,6 +194,9 @@ func (r *request) setDeleteMonitorRequest(req DeleteMonitorRequest) error {
 	return nil
 }
 
+// Returns an XMLMonitors struct,
+// containing a list of monitors with their associated data,
+// or an error
 func (ad *Monitors) Get(req GetMonitorsRequest) (*XMLMonitors, error) {
 	r := ad.c.newRequest("POST", "/getMonitors")
 	err := r.setGetMonitorsRequest(req)
@@ -186,6 +218,8 @@ func (ad *Monitors) Get(req GetMonitorsRequest) (*XMLMonitors, error) {
 	return out, nil
 }
 
+// Helper func for Get to construct http request body
+// using the provided GetMonitorsRequest struct
 func (r *request) setGetMonitorsRequest(req GetMonitorsRequest) error {
 	if req.MonitorId == 0 {
 		return errors.New("MonitorId: required value")


### PR DESCRIPTION
### **User description**
NewClient should accept a `*http.Client`, allowing users to provide things like a desired timeout. If the same behavior of an `http.defaultClient` is desired, that can be passed as the parameter (i.e. in api_test.go).

Additionally, I'm updating/adding go doc comments to improve documentation of the package.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added support for custom `http.Client` in `NewClient`.

- Enhanced documentation with detailed comments for structs and methods.

- Updated tests to accommodate custom `http.Client` usage.

- Improved code clarity with helper functions and structured comments.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>accountdetails.go</strong><dd><code>Enhance documentation for account details functionality</code>&nbsp; &nbsp; </dd></summary>
<hr>

api/accountdetails.go

<li>Added detailed comments for <code>Account</code> struct and methods.<br> <li> Improved documentation for <code>AccountDetails</code> and its <code>Get</code> method.


</details>


  </td>
  <td><a href="https://github.com/uptimerobot/uptimerobot-go/pull/10/files#diff-4f5f0fb0986e0d10556add85aed4d8bf6331d2881f6405bedaa44e999ca64c01">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>monitors.go</strong><dd><code>Improve documentation for monitor operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/monitors.go

<li>Added detailed comments for monitor-related structs and methods.<br> <li> Improved helper function documentation for monitor operations.<br> <li> Enhanced clarity in monitor request and response handling.


</details>


  </td>
  <td><a href="https://github.com/uptimerobot/uptimerobot-go/pull/10/files#diff-0b913bfc5d8ffba0537294539a7e70c1d998f2a8181c33993b9019f8206917d5">+38/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.go</strong><dd><code>Support custom `http.Client` in `NewClient`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/api.go

<li>Modified <code>NewClient</code> to accept a custom <code>http.Client</code>.<br> <li> Updated comments to reflect the new functionality.<br> <li> Improved helper function documentation.


</details>


  </td>
  <td><a href="https://github.com/uptimerobot/uptimerobot-go/pull/10/files#diff-bf98d5fab5bcfabded9769069e7318683f549ec91cff84c5f87a9ae3a3ca3d8d">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_test.go</strong><dd><code>Update tests for custom `http.Client` support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/api_test.go

<li>Updated test setup to use the new <code>NewClient</code> signature.<br> <li> Ensured compatibility with custom <code>http.Client</code>.


</details>


  </td>
  <td><a href="https://github.com/uptimerobot/uptimerobot-go/pull/10/files#diff-f11bd9dcf3ad607c0a7bf74dc50ac921a34cd854a4087517e24ca377f4c0dfbe">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>